### PR TITLE
Fix total winnings tracking

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -331,7 +331,7 @@ function checkWin() {
   if (isWagerSaver) {
     if (totalWin > minBet) {
       coins += totalWin;
-      coins += totalWinnings;
+      totalWinnings += totalWin;
       updateStatsPanel();
       updateCoinDisplay();
 
@@ -355,7 +355,7 @@ function checkWin() {
   } else {
     if (totalWin > 0) {
       coins += totalWin;
-      coins += totalWinnings;
+      totalWinnings += totalWin;
       updateStatsPanel();
       updateCoinDisplay();
       // Show user total winnings, as well as major and minor win count


### PR DESCRIPTION
## Summary
- accumulate lifetime winnings instead of readding them each spin

## Testing
- `node --check gameLogic.js`
- `node --check ui.js`
- `node --check data.js`


------
https://chatgpt.com/codex/tasks/task_e_683f789626dc832d9eb2573b0b774f2a